### PR TITLE
refactor(slt_common): OdomDataBuffer uses int64_t as map key

### DIFF
--- a/slt_common/include/slt_common/odom_data_buffer.hpp
+++ b/slt_common/include/slt_common/odom_data_buffer.hpp
@@ -44,7 +44,7 @@ public:
   void set_max_buffer_size(size_t max_buffer_size);
 
 private:
-  std::map<double, slt_common::OdomData> buffer_;
+  std::map<int64_t, slt_common::OdomData> buffer_;
   size_t max_buffer_size_;
 };
 }  // namespace slt_common

--- a/slt_common/src/odom_data_buffer.cpp
+++ b/slt_common/src/odom_data_buffer.cpp
@@ -23,7 +23,7 @@ OdomDataBuffer::OdomDataBuffer(size_t max_buffer_size) {max_buffer_size_ = max_b
 
 void OdomDataBuffer::add_data(const OdomData & data)
 {
-  buffer_.insert({static_cast<int64_t>(data.time), data});
+  buffer_.insert({static_cast<int64_t>(data.time * 1000000), data});
   if (buffer_.size() > max_buffer_size_) {
     buffer_.erase(buffer_.begin());
   }
@@ -31,7 +31,7 @@ void OdomDataBuffer::add_data(const OdomData & data)
 
 bool OdomDataBuffer::get_data(double time, OdomData & data)
 {
-  if (auto it = buffer_.find(static_cast<int64_t>(time)); it != buffer_.end()) {
+  if (auto it = buffer_.find(static_cast<int64_t>(time * 1000000)); it != buffer_.end()) {
     data = it->second;
     return true;
   }
@@ -43,7 +43,7 @@ bool OdomDataBuffer::get_nearest_data(double time, OdomData & data)
   if (buffer_.empty()) {
     return false;
   }
-  int64_t time_us = static_cast<int64_t>(time);
+  int64_t time_us = static_cast<int64_t>(time * 1000000);
   auto cur = buffer_.lower_bound(time_us);
   if (cur == buffer_.end()) {
     // the last
@@ -68,7 +68,7 @@ bool OdomDataBuffer::get_interpolated_data(double time, OdomData & data)
   if (buffer_.empty()) {
     return false;
   }
-  int64_t time_us = static_cast<int64_t>(time);
+  int64_t time_us = static_cast<int64_t>(time * 1000000);
   if (time_us < buffer_.begin()->first || time_us > buffer_.rbegin()->first) {
     return false;
   }
@@ -104,7 +104,7 @@ double OdomDataBuffer::get_start_time()
   if (buffer_.empty()) {
     return -1;
   }
-  return static_cast<double>(buffer_.begin()->first);
+  return static_cast<double>(buffer_.begin()->first) / 1000000.0;
 }
 
 double OdomDataBuffer::get_end_time()
@@ -112,19 +112,19 @@ double OdomDataBuffer::get_end_time()
   if (buffer_.empty()) {
     return -1;
   }
-  return static_cast<double>(buffer_.rbegin()->first);
+  return static_cast<double>(buffer_.rbegin()->first) / 1000000.0;
 }
 
 void OdomDataBuffer::remove(double time)
 {
-  if (auto it = buffer_.find(static_cast<int64_t>(time)); it != buffer_.end()) {
+  if (auto it = buffer_.find(static_cast<int64_t>(time * 1000000)); it != buffer_.end()) {
     buffer_.erase(it);
   }
 }
 
 void OdomDataBuffer::remove_before(double time)
 {
-  auto cur = buffer_.lower_bound(static_cast<int64_t>(time));
+  auto cur = buffer_.lower_bound(static_cast<int64_t>(time * 1000000));
   if (cur != buffer_.begin()) {
     cur--;
     buffer_.erase(buffer_.begin(), cur);
@@ -133,7 +133,7 @@ void OdomDataBuffer::remove_before(double time)
 
 void OdomDataBuffer::remove_after(double time)
 {
-  auto cur = buffer_.upper_bound(static_cast<int64_t>(time));
+  auto cur = buffer_.upper_bound(static_cast<int64_t>(time * 1000000));
   buffer_.erase(cur, buffer_.end());
 }
 

--- a/slt_common/src/odom_data_buffer.cpp
+++ b/slt_common/src/odom_data_buffer.cpp
@@ -23,7 +23,7 @@ OdomDataBuffer::OdomDataBuffer(size_t max_buffer_size) {max_buffer_size_ = max_b
 
 void OdomDataBuffer::add_data(const OdomData & data)
 {
-  buffer_.insert({data.time, data});
+  buffer_.insert({static_cast<int64_t>(data.time), data});
   if (buffer_.size() > max_buffer_size_) {
     buffer_.erase(buffer_.begin());
   }
@@ -31,7 +31,7 @@ void OdomDataBuffer::add_data(const OdomData & data)
 
 bool OdomDataBuffer::get_data(double time, OdomData & data)
 {
-  if (auto it = buffer_.find(time); it != buffer_.end()) {
+  if (auto it = buffer_.find(static_cast<int64_t>(time)); it != buffer_.end()) {
     data = it->second;
     return true;
   }
@@ -43,7 +43,8 @@ bool OdomDataBuffer::get_nearest_data(double time, OdomData & data)
   if (buffer_.empty()) {
     return false;
   }
-  auto cur = buffer_.lower_bound(time);
+  int64_t time_us = static_cast<int64_t>(time);
+  auto cur = buffer_.lower_bound(time_us);
   if (cur == buffer_.end()) {
     // the last
     data = buffer_.rbegin()->second;
@@ -53,7 +54,7 @@ bool OdomDataBuffer::get_nearest_data(double time, OdomData & data)
   } else {
     // choose between prev and cur
     auto prev = std::prev(cur);
-    if (fabs(prev->first - time) < fabs(cur->first - time)) {
+    if (std::abs(prev->first - time_us) < std::abs(cur->first - time_us)) {
       data = prev->second;
     } else {
       data = cur->second;
@@ -67,12 +68,17 @@ bool OdomDataBuffer::get_interpolated_data(double time, OdomData & data)
   if (buffer_.empty()) {
     return false;
   }
-  if (time < buffer_.begin()->first || time > buffer_.rbegin()->first) {
+  int64_t time_us = static_cast<int64_t>(time);
+  if (time_us < buffer_.begin()->first || time_us > buffer_.rbegin()->first) {
     return false;
   }
-  auto cur = buffer_.lower_bound(time);
+  auto cur = buffer_.lower_bound(time_us);
   if (cur == buffer_.end()) {
     return false;
+  }
+  if (cur->first == time_us) {
+    // exact match, no need to interpolate
+    data = cur->second;
   } else if (cur == buffer_.begin()) {
     // the first
     data = cur->second;
@@ -98,7 +104,7 @@ double OdomDataBuffer::get_start_time()
   if (buffer_.empty()) {
     return -1;
   }
-  return buffer_.begin()->first;
+  return static_cast<double>(buffer_.begin()->first);
 }
 
 double OdomDataBuffer::get_end_time()
@@ -106,19 +112,19 @@ double OdomDataBuffer::get_end_time()
   if (buffer_.empty()) {
     return -1;
   }
-  return buffer_.rbegin()->first;
+  return static_cast<double>(buffer_.rbegin()->first);
 }
 
 void OdomDataBuffer::remove(double time)
 {
-  if (auto it = buffer_.find(time); it != buffer_.end()) {
+  if (auto it = buffer_.find(static_cast<int64_t>(time)); it != buffer_.end()) {
     buffer_.erase(it);
   }
 }
 
 void OdomDataBuffer::remove_before(double time)
 {
-  auto cur = buffer_.lower_bound(time);
+  auto cur = buffer_.lower_bound(static_cast<int64_t>(time));
   if (cur != buffer_.begin()) {
     cur--;
     buffer_.erase(buffer_.begin(), cur);
@@ -127,7 +133,7 @@ void OdomDataBuffer::remove_before(double time)
 
 void OdomDataBuffer::remove_after(double time)
 {
-  auto cur = buffer_.upper_bound(time);
+  auto cur = buffer_.upper_bound(static_cast<int64_t>(time));
   buffer_.erase(cur, buffer_.end());
 }
 


### PR DESCRIPTION
- Internal map now stores timestamps as int64_t (microseconds)
- Interface unchanged (double time parameter)
- get_interpolated_data returns exact match directly without interpolation